### PR TITLE
User registration bug fix. Now need to investigate slowdown on game s…

### DIFF
--- a/gremlin-eye.Server/.gitignore
+++ b/gremlin-eye.Server/.gitignore
@@ -2,7 +2,7 @@
 appsettings.*.json
 
 snippet.txt
-testCurl.ps1
+testCurl*.ps1
 
 obj/
 bin/

--- a/gremlin-eye.Server/Repositories/UserRepository.cs
+++ b/gremlin-eye.Server/Repositories/UserRepository.cs
@@ -81,7 +81,7 @@ namespace gremlin_eye.Server.Repositories
         {
             if (string.IsNullOrEmpty(registerRequest.Username) || string.IsNullOrEmpty(registerRequest.Email))
                 return null;
-            return _context.Users.Where(u => registerRequest.Username == u.Email || registerRequest.Email == registerRequest.Email).FirstOrDefault();
+            return _context.Users.Where(u => registerRequest.Username == u.UserName || registerRequest.Email == u.Email).FirstOrDefault();
         }
 
         public AppUser? GetUserByEmail(string email)


### PR DESCRIPTION
…earch/filters. According to ECS logs, timeout happens in the middle of a query when more filters are applied, so it probably has to do with the nested predicates in the search function in the backend.