### PR TITLE
Turning off logging in production, should help speed up application a…

### DIFF
--- a/gremlin-eye.Server/appsettings.json
+++ b/gremlin-eye.Server/appsettings.json
@@ -1,9 +1,3 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft.AspNetCore": "Warning"
-    }
-  },
   "AllowedHosts": "*"
 }


### PR DESCRIPTION
…nd generally safer. Upgrading the db instance size seemed to do the trick with fixing the performance since the CPU Utilization was in the 30s-40s and RAM was only 1 GB.